### PR TITLE
Various minor adjustments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
     let mut game = Game::new(Size::new(1024.0, 600.0));
 
     // Event handling
-    for e in window.events() {
+    for e in window.events().ups(60).max_fps(60) {
         match e {
             Event::Input(Input::Press(Button::Keyboard(key))) => {
                 game.key_press(key);

--- a/src/models/bullet.rs
+++ b/src/models/bullet.rs
@@ -28,8 +28,8 @@ impl Bullet {
     }
 
     /// Update the bullet's position
-    pub fn update(&mut self, elapsed_time: f64) {
-        self.advance(elapsed_time);
+    pub fn update(&mut self, units: f64) {
+        self.advance(units);
     }
 }
 


### PR DESCRIPTION
Even though the subject suggests it's minor, the game-play is affected
too, which might need additional tweaking.

The primary change was to be explicit about the amount of updates
per second, and assure the game-state is based on the delta-time, not
the update frequency.

Here is a listing of the changes in detail:
- ship movement is now based on the delta-time.
- bullet rate was reduced to 20/s. It shouldn't be higher than the
  designated updates per second in the window's event loop for
  consistent results.
- Assure enemys are not colliding with the player when spawned.
- add `reset()` method to be more explicit.
- explicit mention of desired updates-per-second and frames-per-second
  in the game window's event loop.
- renamed bullet `update()` arg to `units` as it is closer to how
  the argument is used.

The recording of this review session will be uploaded in the cause of the day and posted here as a comment.
