### PR TITLE
Lower ellipse resolution for higher frame rate

### DIFF
--- a/src/models/bullet.rs
+++ b/src/models/bullet.rs
@@ -22,7 +22,7 @@ impl Bullet {
 
     /// Draw the bullet
     pub fn draw(&self, c: &Context, gl: &mut GlGraphics) {
-        Ellipse::new(color::BLUE).draw(
+        Ellipse::new(color::BLUE).resolution(8).draw(
             [self.x() - self.radius(), self.y() - self.radius(), self.diameter(), self.diameter()],
             &c.draw_state, c.transform, gl);
     }

--- a/src/models/enemy.rs
+++ b/src/models/enemy.rs
@@ -20,7 +20,7 @@ impl Enemy {
 
     /// Draw the enemy
     pub fn draw(&self, c: &Context, gl: &mut GlGraphics) {
-        Ellipse::new([1.0, 1.0, 0.0, 1.0]).draw(
+        Ellipse::new([1.0, 1.0, 0.0, 1.0]).resolution(16).draw(
             [self.x() - 10.0, self.y() - 10.0, 20.0, 20.0],
             &c.draw_state, c.transform, gl);
     }

--- a/src/models/particle.rs
+++ b/src/models/particle.rs
@@ -26,7 +26,7 @@ impl Particle {
     /// Draw the particle
     pub fn draw(&self, c: &Context, gl: &mut GlGraphics) {
         let radius = 5.0 * self.ttl;
-        Ellipse::new(color::VIOLET).draw(
+        Ellipse::new(color::VIOLET).resolution(8).draw(
             [self.x() - radius, self.y() - radius, radius * 2.0, radius * 2.0],
             &c.draw_state, c.transform, gl);
     }


### PR DESCRIPTION
The default `resolution` parameter for ellipses is 128, which is
ridiculously high for tiny circles. Lowering has no visible effect
except for a much better frame rate in action packed moments.
