### PR TITLE
Remove glob import of piston_window

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,8 @@ mod game;
 mod models;
 mod traits;
 
-use piston_window::*;
+use piston_window::{Button, Event, Events, EventLoop, Input, Motion, OpenGL, PistonWindow,
+    WindowSettings};
 use opengl_graphics::GlGraphics;
 
 use game::Game;


### PR DESCRIPTION
Using rocket for an example, I find it a little easier to understand explicit imports rather than to glob entire crates.
