### PR TITLE
Add requirements section for Rust version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,11 @@ Left     | Rotate left
 Right    | Rotate right
 Space    | Shoot
 
-## Running it with Cargo
+## Requirements
+
+Rocket targets the latest stable version of Rust.
+
+### Running it with Cargo
 
 As always, it is a real pleasure to work with Cargo. You only need the following:
 


### PR DESCRIPTION
Closes #21.  For future readers, helps direct them to stable Rust as all versions of stable `rustc` seem to play nicely with Piston.
