### PR TITLE
Reuse game size value

### DIFF
--- a/src/drawing/size.rs
+++ b/src/drawing/size.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 use super::Point;
 
 /// A `Size` represents a region in space
-#[derive(Clone, Default)]
+#[derive(Clone, Copy, Default)]
 pub struct Size {
     pub width: f64,
     pub height: f64

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,9 +19,11 @@ use game::Game;
 fn main() {
     let opengl = OpenGL::V3_2;
 
-    let mut game = Game::new(drawing::Size::new(1024.0, 600.0));
+    let game_size: drawing::Size = drawing::Size::new(1024.0, 600.0);
+    let mut game = Game::new(game_size);
 
-    let mut window: PistonWindow = WindowSettings::new("Rocket!", [1024, 600])
+    let mut window: PistonWindow = WindowSettings::new(
+        "Rocket!", [game_size.width as u32, game_size.height as u32])
         .opengl(opengl).samples(8).exit_on_esc(true).build().unwrap();
 
     window.set_ups(60);


### PR DESCRIPTION
Possibly a small improvement to avoid duplication of the same values.

Another option is we could make `game_size` `const`, but it seemed like then we can't use `::new`, we'd have to create the `struct` manually. Wasn't sure if having this type break that pattern was worth it.