### PR TITLE
Format code

### DIFF
--- a/src/drawing/point.rs
+++ b/src/drawing/point.rs
@@ -12,7 +12,7 @@ pub struct Point {
 impl Point {
     /// Returns a new `Point` with the given coordinates
     pub fn new(x: f64, y: f64) -> Point {
-        Point { x: x, y: y}
+        Point { x: x, y: y }
     }
 
     /// Returns a random `Point` within the given bounds (exclusive)
@@ -26,7 +26,7 @@ impl Point {
     /// Returns the squared distance from this point to the given one
     pub fn squared_distance_to(&self, target: &Point) -> f64 {
         (self.x - target.x) * (self.x - target.x)
-        + (self.y - target.y) * (self.y - target.y)
+            + (self.y - target.y) * (self.y - target.y)
     }
 
     /// Rotates the point through the origin in the given angle (radians)

--- a/src/drawing/size.rs
+++ b/src/drawing/size.rs
@@ -18,7 +18,7 @@ impl Size {
     /// Returns true if the `Point` is contained in this `Size` or false otherwise
     pub fn contains(&self, point: Point) -> bool {
         0.0 <= point.x && point.x <= self.width
-        && 0.0 <= point.y && point.y <= self.height
+            && 0.0 <= point.y && point.y <= self.height
     }
 
     /// Returns a random x coordinate within the bounds of this `Size`

--- a/src/game.rs
+++ b/src/game.rs
@@ -116,7 +116,7 @@ impl Game {
         // Axis 0 is left stick (XInput). -1.0 left to 1.0 right
         if controller.axis == 0 {
             match controller.position {
-                - 1.0 ... - 0.2 => {
+                -1.0 ... -0.2 => {
                     self.actions.rotate_left = true;
                     self.actions.rotate_right = false;
                 },
@@ -124,7 +124,7 @@ impl Game {
                     self.actions.rotate_left = false;
                     self.actions.rotate_right = true;
                 },
-                - 0.199 ... 0.199 => {
+                -0.199 ... 0.199 => {
                     self.actions.rotate_left = false;
                     self.actions.rotate_right = false;
                 },
@@ -135,10 +135,10 @@ impl Game {
         // Axis 5 is right trigger (XInput). -1.0 is not pressed, 1.0 is fully pressed
         if controller.axis == 5 {
             match controller.position {
-                - 0.8 ... 1.0 => {
+                -0.8 ... 1.0 => {
                     self.actions.boost = true;
                 },
-                - 1.0 ... - 0.799 => {
+                -1.0 ... -0.799 => {
                     self.actions.boost = false;
                 },
                 _ => {}

--- a/src/game.rs
+++ b/src/game.rs
@@ -113,11 +113,10 @@ impl Game {
 
     /// Handles a controller axis input
     pub fn handle_axis(&mut self, controller: ControllerAxisArgs) {
-
         // Axis 0 is left stick (XInput). -1.0 left to 1.0 right
         if controller.axis == 0 {
             match controller.position {
-                -1.0 ... -0.2 => {
+                - 1.0 ... - 0.2 => {
                     self.actions.rotate_left = true;
                     self.actions.rotate_right = false;
                 },
@@ -125,9 +124,9 @@ impl Game {
                     self.actions.rotate_left = false;
                     self.actions.rotate_right = true;
                 },
-                -0.199 ... 0.199 => {
+                - 0.199 ... 0.199 => {
                     self.actions.rotate_left = false;
-                    self.actions.rotate_right = false;   
+                    self.actions.rotate_right = false;
                 },
                 _ => {}
             }
@@ -136,10 +135,10 @@ impl Game {
         // Axis 5 is right trigger (XInput). -1.0 is not pressed, 1.0 is fully pressed
         if controller.axis == 5 {
             match controller.position {
-                -0.8 ... 1.0 => {
+                - 0.8 ... 1.0 => {
                     self.actions.boost = true;
                 },
-                -1.0 ... -0.799 => {
+                - 1.0 ... - 0.799 => {
                     self.actions.boost = false;
                 },
                 _ => {}
@@ -183,7 +182,7 @@ impl Game {
         };
 
         // Set speed and advance the player with wrap around
-        let speed = if self.actions.boost { 400.0  } else { 200.0 };
+        let speed = if self.actions.boost { 400.0 } else { 200.0 };
         self.world.player.advance_wrapping(dt * speed, self.world.size.clone());
 
         // Update particles
@@ -212,9 +211,10 @@ impl Game {
         }
 
         // Remove bullets outside the viewport
-        { // Shorten the lifetime of size
-        let size = &self.world.size;
-        self.world.bullets.retain(|b| size.contains(b.position()));
+        {
+            // Shorten the lifetime of size
+            let size = &self.world.size;
+            self.world.bullets.retain(|b| size.contains(b.position()));
         }
 
         // Spawn enemies at random locations
@@ -246,27 +246,28 @@ impl Game {
     fn handle_bullet_collisions(&mut self) {
         let old_enemy_count = self.world.enemies.len();
 
-        { // We introduce a scope to shorten the lifetime of the borrows below
-        // The references are to avoid using self in the closure
-        // (the borrow checker doesn't like that)
-        let bullets = &mut self.world.bullets;
-        let enemies = &mut self.world.enemies;
-        let particles = &mut self.world.particles;
+        {
+            // We introduce a scope to shorten the lifetime of the borrows below
+            // The references are to avoid using self in the closure
+            // (the borrow checker doesn't like that)
+            let bullets = &mut self.world.bullets;
+            let enemies = &mut self.world.enemies;
+            let particles = &mut self.world.particles;
 
-        bullets.retain(|bullet| {
-            // Remove the first enemy that collides with a bullet (if any)
-            // Add an explosion on its place
-            if let Some((index, position)) = enemies.iter().enumerate()
-                .find(|&(_, enemy)| enemy.collides_with(bullet))
-                .map(|(index, enemy)| (index, enemy.position()))
-            {
-                Game::make_explosion(particles, position, 10);
-                enemies.remove(index);
-                false
-            } else {
-                true
-            }
-        });
+            bullets.retain(|bullet| {
+                // Remove the first enemy that collides with a bullet (if any)
+                // Add an explosion on its place
+                if let Some((index, position)) = enemies.iter().enumerate()
+                    .find(|&(_, enemy)| enemy.collides_with(bullet))
+                    .map(|(index, enemy)| (index, enemy.position()))
+                    {
+                        Game::make_explosion(particles, position, 10);
+                        enemies.remove(index);
+                        false
+                    } else {
+                    true
+                }
+            });
         }
 
         let killed_enemies = (old_enemy_count - self.world.enemies.len()) as u32;
@@ -293,7 +294,7 @@ impl Game {
             // Make an explosion where the player was
             let ppos = self.world.player.position();
             Game::make_explosion(&mut self.world.particles, ppos, 8);
-            
+
             self.reset();
         }
     }

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -31,7 +31,7 @@ impl Player {
     pub fn draw(&self, c: &Context, gl: &mut GlGraphics) {
         // Set the center of the player as the origin and rotate it
         let transform = c.transform.trans(self.x(), self.y())
-                                   .rot_rad(self.direction());
+            .rot_rad(self.direction());
 
         // Draw a rectangle on the position of the player
         Polygon::new(color::RED).draw(POLYGON, &c.draw_state, transform, gl);


### PR DESCRIPTION
This PR runs the `intellij-rust` formatter to make code style consistent* with the [Rust style guide](https://aturon.github.io/).

*Line wrapping on width 99 was not performed in this PR. @aochagavia, any interest in wrapping at 99? I think it could make rocket a little bit easier for others to use as a reference. I'm happy to add it to the PR.