### PR TITLE
Don't run executable in AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,4 +33,3 @@ build: false
 # Equivalent to Travis' `script` phase
 test_script:
   - cargo build --verbose
-  - cargo run


### PR DESCRIPTION
We shouldn't `cargo run` in our Windows CI build. 😄

Should fix the AppVeyor build (#46).