### PR TITLE
Simplify piston dependencies by using piston_window reexports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,8 +3,6 @@ name = "rocket"
 version = "0.2.0"
 dependencies = [
  "itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston2d-graphics 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston2d-opengl_graphics 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston_window 0.60.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,6 @@ build = "build.rs"
 
 [dependencies]
 itertools = "0.4.19"
-piston = "0.27.0"
 piston_window = "0.60.0"
-piston2d-graphics = "0.19.0"
 piston2d-opengl_graphics = "0.36.1"
 rand = "0.3.14"

--- a/src/game.rs
+++ b/src/game.rs
@@ -3,11 +3,10 @@
 use std::f64;
 use std::env::current_exe;
 
-use graphics::{self, Transformed};
 use itertools;
 use opengl_graphics::GlGraphics;
 use opengl_graphics::glyph_cache::GlyphCache;
-use piston::input::{ControllerButton, ControllerAxisArgs, Key};
+use piston_window::{clear, ControllerButton, Context, ControllerAxisArgs, Key, text, Transformed};
 use rand::{self, ThreadRng};
 
 use drawing::{color, Point, Size};
@@ -163,20 +162,20 @@ impl Game {
     }
 
     /// Renders the game to the screen
-    pub fn render(&mut self, c: graphics::context::Context, g: &mut GlGraphics) {
+    pub fn render(&mut self, c: Context, g: &mut GlGraphics) {
         // Clear everything
-        graphics::clear(color::BLACK, g);
+        clear(color::BLACK, g);
 
         // Render the world
         self.world.render(c, g);
 
         // Render the score
-        graphics::text(color::ORANGE,
-                       22,
-                       &format!("Score: {}", self.score),
-                       &mut self.resources.font,
-                       c.trans(10.0, 20.0).transform,
-                       g);
+        text(color::ORANGE,
+             22,
+             &format!("Score: {}", self.score),
+             &mut self.resources.font,
+             c.trans(10.0, 20.0).transform,
+             g);
     }
 
     /// Updates the game
@@ -257,7 +256,7 @@ impl Game {
     /// will be removed. Additionally, the score will be increased by 10
     fn handle_bullet_collisions(&mut self) {
         let old_enemy_count = self.world.enemies.len();
-        
+
         // We introduce a scope to shorten the lifetime of the borrows below
         {
             let bullets = &mut self.world.bullets;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 extern crate piston_window;
-extern crate graphics;
 extern crate itertools;
 extern crate opengl_graphics;
-extern crate piston;
 extern crate rand;
 
 mod drawing;

--- a/src/models/bullet.rs
+++ b/src/models/bullet.rs
@@ -2,8 +2,8 @@ use drawing::color;
 use super::Vector;
 use traits::{Advance, Collide, Position};
 
-use graphics::{Context, ellipse};
 use opengl_graphics::GlGraphics;
+use piston_window::{Context, ellipse};
 
 /// Bullets are spawned when the player shoots
 ///

--- a/src/models/enemy.rs
+++ b/src/models/enemy.rs
@@ -2,8 +2,8 @@ use drawing::{color, Point};
 use super::Vector;
 use traits::{Advance, Collide, Position};
 
-use graphics::{Context, ellipse};
 use opengl_graphics::GlGraphics;
+use piston_window::{Context, ellipse};
 
 /// Enemies follow the player in order to cause a collision and let him explode 
 pub struct Enemy {

--- a/src/models/particle.rs
+++ b/src/models/particle.rs
@@ -2,8 +2,8 @@ use drawing::color;
 use super::Vector;
 use traits::{Advance, Position};
 
-use graphics::{Context, ellipse};
 use opengl_graphics::GlGraphics;
+use piston_window::{Context, ellipse};
 
 /// A model representing a particle
 ///

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -1,5 +1,5 @@
-use graphics::{Context, polygon, Transformed};
 use opengl_graphics::GlGraphics;
+use piston_window::{Context, polygon, Transformed};
 use rand::Rng;
 
 use drawing::{color, Point, Size};

--- a/src/models/world.rs
+++ b/src/models/world.rs
@@ -1,5 +1,5 @@
-use graphics;
 use opengl_graphics::GlGraphics;
+use piston_window::{Context};
 use rand::Rng;
 
 use drawing::Size;
@@ -27,7 +27,7 @@ impl World {
     }
 
     /// Renders the world and everything in it
-    pub fn render(&self, c: graphics::context::Context, g: &mut GlGraphics) {
+    pub fn render(&self, c: Context, g: &mut GlGraphics) {
         for particle in &self.particles {
             particle.draw(&c, g);
         }


### PR DESCRIPTION
This allows rocket to not need to avoid having to keep the `piston_window`, `piston`, and `piston2d-graphics`dependancies up to date and in sync.

The small downside is that it's a little less explicit which submodules certain imports are coming from, but I think the dependency simplification is worth it and I believe this is also the preferred way to use Piston now.