### PR TITLE
Normalize line endings via git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto


### PR DESCRIPTION
Some files were being checked out as CRLF on Mac, so this should help solve that issue in the future.