### PR TITLE
Update itertools dependencies to new itertools-num

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "rocket"
 version = "0.2.0"
 dependencies = [
- "itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools-num 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston2d-opengl_graphics 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston_window 0.60.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -342,9 +342,12 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "itertools"
-version = "0.4.19"
+name = "itertools-num"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "itoa"
@@ -997,7 +1000,7 @@ dependencies = [
 "checksum image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "559d5ebbe9ec73111799e49c07717944b244f8accf5de33a8a8128bc3ecd2e00"
 "checksum inflate 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e7e0062d2dc2f17d2f13750d95316ae8a2ff909af0fda957084f5defd87c43bb"
 "checksum interpolation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "84e53e2877f735534c2d3cdbb5ba1d04ee11107f599a1e811ab0ff3dd93fe66e"
-"checksum itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "c4a9b56eb56058f43dc66e58f40a214b2ccbc9f3df51861b63d51dec7b65bc3f"
+"checksum itertools-num 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d78fa608383e6e608ba36f962ac991d5d6878d7203eb93b4711b14fa6717813"
 "checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
 "checksum jpeg-decoder 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f1a2c12387f1adb21a9a2a096b5bc5f424a21729ea8e535fdf58681d396b6bbe"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Adolfo Ochagavía <aochagavia92@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-itertools = "0.4.19"
+itertools-num = "0.1.1"
 piston_window = "0.60.0"
 piston2d-opengl_graphics = "0.36.1"
 rand = "0.3.14"

--- a/src/game.rs
+++ b/src/game.rs
@@ -3,7 +3,7 @@
 use std::f64;
 use std::env::current_exe;
 
-use itertools;
+use itertools_num;
 use opengl_graphics::GlGraphics;
 use opengl_graphics::glyph_cache::GlyphCache;
 use piston_window::{clear, ControllerButton, Context, ControllerAxisArgs, Key, text, Transformed};
@@ -310,7 +310,7 @@ impl Game {
 
     /// Generates a new explosion of the given intensity at the given position. This works best with values between 5 and 25
     fn make_explosion(particles: &mut Vec<Particle>, position: Point, intensity: u8) {
-        for rotation in itertools::linspace(0.0, 2.0 * f64::consts::PI, 30) {
+        for rotation in itertools_num::linspace(0.0, 2.0 * f64::consts::PI, 30) {
             for ttl in (1..intensity).map(|x| (x as f64) / 10.0) {
                 particles.push(Particle::new(Vector::new(position.clone(), rotation), ttl));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 extern crate piston_window;
-extern crate itertools;
+extern crate itertools_num;
 extern crate opengl_graphics;
 extern crate rand;
 


### PR DESCRIPTION
`linespace` has been moved to the `itertools-num` crate since version 0.5.0: https://github.com/bluss/rust-itertools#recent-changes