### PR TITLE
Wrap lines at 100 width

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,11 @@
 Rocket
 ======
 
-[![Build Status](https://travis-ci.org/aochagavia/rocket.svg)](https://travis-ci.org/aochagavia/rocket)
-[![Build status](https://ci.appveyor.com/api/projects/status/its182aar6vol45b?svg=true)](https://ci.appveyor.com/project/aochagavia/rocket)
+[![Travis Build Status][travis-build-status-svg]][travis-build-status] 
+[![AppVeyor Build Status][appveyor-build-status-svg]][appveyor-build-status]
 
-> Rocket is a toy game written in Rust, using the Piston library. The code is thoroughly commented in order to help people to follow it easily.
+> Rocket is a toy game written in Rust, using the Piston library. The code is thoroughly 
+commented in order to help people to follow it easily.
 
 ## Screenshots
 
@@ -16,7 +17,8 @@ You can find more screenshots in the [screenshots] directory
 
 ## How to play
 
-As you can see in the screenshots below, you are the red rocket and have to save the world from the yellow invaders. To do so, you can use the following controls:
+As you can see in the screenshots below, you are the red rocket and have to save the world from 
+the yellow invaders. To do so, you can use the following controls:
 
 Keyboard | Action
 -------- | ------------
@@ -39,8 +41,19 @@ cargo run --release
 
 ## Why?
 
-After having implemented some toy games in C++ using SDL and SFML, I thought it would be a good idea to try the same in Rust. Additionally, I had written a similar game in Haskell and wanted to port it to see the similarities and differences between Haskell and Rust. Another reason to program this game was to have an easy to follow Rust project that could be useful for people learning the language.
+After having implemented some toy games in C++ using SDL and SFML, I thought it would be a 
+good idea to try the same in Rust. Additionally, I had written a similar game in Haskell and 
+wanted to port it to see the similarities and differences between Haskell and Rust. Another 
+reason to program this game was to have an easy to follow Rust project that could be useful 
+for people learning the language.
 
 ## License
 
 MIT
+
+<!-- Badges -->
+[travis-build-status]: https://travis-ci.org/aochagavia/rocket
+[travis-build-status-svg]: https://travis-ci.org/aochagavia/rocket.svg
+
+[appveyor-build-status]: https://ci.appveyor.com/project/aochagavia/rocket
+[appveyor-build-status-svg]: https://ci.appveyor.com/api/projects/status/its182aar6vol45b?svg=true

--- a/src/game.rs
+++ b/src/game.rs
@@ -82,7 +82,9 @@ impl Game {
             actions: Actions::default(),
             timers: Timers::default(),
             rng: rng,
-            resources: Resources { font: GlyphCache::new(&exe_directory.join("resources/FiraMono-Bold.ttf")).unwrap() }
+            resources: Resources {
+                font: GlyphCache::new(&exe_directory.join("resources/FiraMono-Bold.ttf")).unwrap()
+            }
         }
     }
 
@@ -207,13 +209,15 @@ impl Game {
         // Add new particles at the player's position, to leave a trail
         if self.timers.current_time - self.timers.last_tail_particle > TRAIL_PARTICLE_RATE {
             self.timers.last_tail_particle = self.timers.current_time;
-            self.world.particles.push(Particle::new(self.world.player.vector.clone().invert(), 0.5));
+            self.world.particles.push(Particle::new(self.world.player.vector.clone().invert(),
+                                                    0.5));
         }
 
         // Add bullets
         if self.actions.shoot && self.timers.current_time - self.timers.last_shoot > BULLET_RATE {
             self.timers.last_shoot = self.timers.current_time;
-            self.world.bullets.push(Bullet::new(Vector::new(self.world.player.nose(), self.world.player.direction())));
+            self.world.bullets.push(Bullet::new(Vector::new(self.world.player.nose(),
+                                                            self.world.player.direction())));
         }
 
         // Advance bullets
@@ -308,7 +312,8 @@ impl Game {
         }
     }
 
-    /// Generates a new explosion of the given intensity at the given position. This works best with values between 5 and 25
+    /// Generates a new explosion of the given intensity at the given position.
+    /// This works best with values between 5 and 25
     fn make_explosion(particles: &mut Vec<Particle>, position: Point, intensity: u8) {
         for rotation in itertools::linspace(0.0, 2.0 * f64::consts::PI, 30) {
             for ttl in (1..intensity).map(|x| (x as f64) / 10.0) {

--- a/src/models/bullet.rs
+++ b/src/models/bullet.rs
@@ -23,7 +23,10 @@ impl Bullet {
     /// Draw the bullet
     pub fn draw(&self, c: &Context, gl: &mut GlGraphics) {
         ellipse(color::BLUE,
-                [self.x() - self.radius(), self.y() - self.radius(), self.diameter(), self.diameter()],
+                [self.x() - self.radius(),
+                    self.y() - self.radius(),
+                    self.diameter(),
+                    self.diameter()],
                 c.transform,
                 gl);
     }


### PR DESCRIPTION
This has the small benefit that it conforms to what `rustfmt` is designed to do, as well makes it so that horizontal scroll bars are not needed when users read `rocket` code in two panes on the same screen.