### PR TITLE
Remove unnecessary clone()'s

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -196,7 +196,7 @@ impl Game {
 
         // Set speed and advance the player with wrap around
         let speed = if self.actions.boost { 2.0 * ADVANCE_SPEED } else { ADVANCE_SPEED };
-        self.world.player.advance_wrapping(dt * speed, self.world.size.clone());
+        self.world.player.advance_wrapping(dt * speed, self.world.size);
 
         // Update particles
         for particle in &mut self.world.particles {
@@ -237,7 +237,7 @@ impl Game {
             self.timers.last_spawned_enemy = self.timers.current_time;
             let mut new_enemy;
             loop {
-                new_enemy = Enemy::new(Vector::random(&mut self.rng, self.world.size.clone()));
+                new_enemy = Enemy::new(Vector::random(&mut self.rng, self.world.size));
                 if !self.world.player.collides_with(&new_enemy) {
                     break;
                 }

--- a/src/models/world.rs
+++ b/src/models/world.rs
@@ -18,7 +18,7 @@ impl World {
     /// Returns a new world of the given size
     pub fn new<R: Rng>(rng: &mut R, size: Size) -> World {
         World {
-            player: Player::random(rng, size.clone()),
+            player: Player::random(rng, size),
             particles: Vec::with_capacity(1000),
             bullets: vec![],
             enemies: vec![],


### PR DESCRIPTION
These were detected by running [clippy](https://github.com/Manishearth/rust-clippy).

Unnecessary to call `clone()` on types that derive `Copy`.