### PR TITLE
Bump dependancies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,8 +3,8 @@ name = "rocket"
 version = "0.2.0"
 dependencies = [
  "itertools-num 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston2d-opengl_graphics 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston_window 0.63.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston2d-opengl_graphics 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston_window 0.64.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -562,7 +562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "piston-gfx_texture"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gfx 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -591,21 +591,21 @@ dependencies = [
 
 [[package]]
 name = "piston2d-gfx_graphics"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "draw_state 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston-gfx_texture 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-gfx_texture 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-shaders_graphics2d 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston2d-graphics 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston2d-graphics 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusttype 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shader_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piston2d-graphics"
-version = "0.20.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "interpolation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "piston2d-opengl_graphics"
-version = "0.39.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -626,22 +626,22 @@ dependencies = [
  "khronos_api 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-shaders_graphics2d 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-texture 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston2d-graphics 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston2d-graphics 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusttype 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shader_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piston_window"
-version = "0.63.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gfx 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_device_gl 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-texture 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston2d-gfx_graphics 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston2d-graphics 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston2d-gfx_graphics 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston2d-graphics 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pistoncore-glutin_window 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shader_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1048,14 +1048,14 @@ dependencies = [
 "checksum phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "07e24b0ca9643bdecd0632f2b3da6b1b89bbb0030e0b992afc1113b23a7bc2f2"
 "checksum piston 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4f907ccf88ec05aca2c594a9b05217fabfc0137258e46109570eb5270a50cf73"
 "checksum piston-float 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b058c3a640efd4bcf63266512e4bb03187192c1b29edd38b16d5a014613e3199"
-"checksum piston-gfx_texture 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c245ec221879d164e6d3068a94e07776dbf1f53a777194adb0e05f7c47c48488"
+"checksum piston-gfx_texture 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63dc17ef92d6641f8fa1c7cf775754977b0c0e8ef65839383d796bca5ffd1902"
 "checksum piston-shaders_graphics2d 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "97bc17dac1dfff3e5cb84116062c7b46ff9d3dc0d88696a46d2f054cf64a10b6"
 "checksum piston-texture 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca39d71646f3b878dd4b0f9758f38d09658b2efd08dbdd9abf9f17000f1b9832"
 "checksum piston-viewport 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c5548a838fd9dc604c96d886c03c303f043a2d85f88719cca59dc7991d86343"
-"checksum piston2d-gfx_graphics 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e587af814e064dad0b523554cde76424232e01e07bf094385ebad03721eb359"
-"checksum piston2d-graphics 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2214ba6b88373e67848b4db23240fb35f882f04b2be81e5379b03f7b92a187d1"
-"checksum piston2d-opengl_graphics 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)" = "95714b68ce47a1faf21b9d192adf2c1cdc6078ffdc537b2a0852dfb946119128"
-"checksum piston_window 0.63.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c0b2dabf54c4693096fd736d0fea73d2676bcfe52dfb8ecd45d7454d5b7aa2f"
+"checksum piston2d-gfx_graphics 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)" = "979168115843b215398597e6b8ffcb77558ed6bb6a59abc66fe7087c36a39069"
+"checksum piston2d-graphics 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d72cce9e129be5f50f5f26b69a064481664b6eccbdf643139563ea20485419f"
+"checksum piston2d-opengl_graphics 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0d6713ba76a0b5fa6c386ba32b30a697c8add1a1b9bc4cec883060ed081eef58"
+"checksum piston_window 0.64.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9bf4d1f734e32a4e0ce552bc7ce9a8caaa8f5427cb50b68d84f68c76d31e0ab1"
 "checksum pistoncore-event_loop 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9aee055fd3c72d3aa75e4e6adebb7c62a8db1a686a03ff73250f213b2d7bbac9"
 "checksum pistoncore-glutin_window 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)" = "78eadd1ac8d08ba2d5813ace5e0ed80dd5c99d381d4a5d0a54701ae765fcce82"
 "checksum pistoncore-input 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6220f05c9339e6b82c7cd5d1b30f064cc06e6503933c15c3422aa8f70c693608"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ build = "build.rs"
 
 [dependencies]
 itertools-num = "0.1.1"
-piston_window = "0.63.0"
-piston2d-opengl_graphics = "0.39.0"
-rand = "0.3.14"
+piston_window = "0.64.0"
+piston2d-opengl_graphics = "0.42.0"
+rand = "0.3.15"


### PR DESCRIPTION
@aochagavia After upgrading to the latest `piston_window`, `rocket` seems to perform poorly (explosions look laggy on my PC). Could you verify behavior before merging? Maybe something needs to be reported to Piston.