### PR TITLE
Player grace area

### DIFF
--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -2,8 +2,10 @@ use rand::Rng;
 
 use super::Size;
 
+use std::ops::{Add, Sub, Mul, Div};
+
 /// A `Point` represents a position in space
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Copy)]
 pub struct Point {
     pub x: f64,
     pub y: f64
@@ -44,5 +46,117 @@ impl Point {
         self.x += other.x;
         self.y += other.y;
         self
+    }
+
+    /// Checks if this point is contained in a circle
+    pub fn intersect_circle(self, center: &Point, radius: f64) -> bool {
+        (self.x - center.x).powi(2) +
+            (self.y - center.y).powi(2) < radius.powi(2)
+    }
+}
+
+/// Implements '==' for Point, as well as its inverse '!='
+impl PartialEq for Point {
+    fn eq (&self, _rhs: &Self) -> bool {
+        (self.x == _rhs.x) && (self.y == _rhs.y)
+    }
+}
+
+/// Implements the '+' operator for Point + Point
+impl Add for Point {
+    type Output = Point;
+
+    fn add(self, _rhs: Point) -> Point {
+        Point {
+            x: self.x + _rhs.x,
+            y: self.y + _rhs.y,
+        }
+    }
+}
+
+/// Implements the '+' operator for Point + f64
+impl Add<f64> for Point {
+    type Output = Point;
+
+    fn add(self, _rhs: f64) -> Point {
+        Point {
+            x: self.x + _rhs,
+            y: self.y + _rhs,
+        }
+    }
+}
+
+/// Implements the '-' operator for Point - Point
+impl Sub for Point {
+    type Output = Point;
+
+    fn sub(self, _rhs: Point) -> Point {
+        Point {
+            x: self.x - _rhs.x,
+            y: self.y - _rhs.y,
+        }
+    }
+}
+
+/// Implements the '-' operator for Point - f64
+impl Sub<f64> for Point {
+    type Output = Point;
+
+    fn sub(self, _rhs: f64) -> Point {
+        Point {
+            x: self.x - _rhs,
+            y: self.y - _rhs,
+        }
+    }
+}
+
+/// Implements the '*' operator for Point * Point
+impl Mul for Point {
+    type Output = Point;
+
+    fn mul(self, _rhs: Point) -> Point {
+        Point {
+            x: self.x * _rhs.x,
+            y: self.y * _rhs.y,
+        }
+    }
+}
+
+/// Implements the '*' operator for Point * f64
+impl Mul<f64> for Point {
+    type Output = Point;
+
+    fn mul(self, _rhs: f64) -> Point {
+        Point {
+            x: self.x * _rhs,
+            y: self.x * _rhs,
+        }
+    }
+}
+
+/// Implements the '/' operator for Point / Point
+impl Div for Point {
+    type Output = Point;
+
+    fn div(self, _rhs: Point) -> Point {
+        assert!(_rhs.x != 0f64);
+        assert!(_rhs.y != 0f64);
+        Point {
+            x: self.x / _rhs.x,
+            y: self.y / _rhs.y,
+        }
+    }
+}
+
+/// Implements the '/' operator for Point / f64:
+impl Div<f64> for Point {
+    type Output = Point;
+
+    fn div(self, _rhs: f64) -> Point {
+        assert!(_rhs != 0f64);
+        Point {
+            x: self.x / _rhs,
+            y: self.y / _rhs,
+        }
     }
 }


### PR DESCRIPTION
This adds a small area around the player where enemies cannot spawn, making it impossible for an enemy to spawn directly in front of the player and taking them out before they can react.  Instead, when the RNG puts an enemy near the player, the new enemy position will be pushed to the closest edge of the player's 'grace area'.

To keep in-line with this being a rust learning project, I also added some overloaded operators for the Point struct.  I didn't use all of them, but went ahead and threw them in there for completion.