### PR TITLE
Enemies speedup as time goes on

### DIFF
--- a/src/controllers/time.rs
+++ b/src/controllers/time.rs
@@ -53,6 +53,7 @@ impl TimeController {
     /// `dt` is the amount of seconds that have passed since the last update
     pub fn update_seconds(&mut self, dt: f64, actions: &Actions, state: &mut GameState) {
         self.current_time += dt;
+        state.difficulty += dt / 100.0;
 
         // Update rocket rotation
         if actions.rotate_left {
@@ -128,7 +129,7 @@ impl TimeController {
 
         // Move enemies in the player's direction
         for enemy in &mut state.world.enemies {
-            enemy.update(dt * ENEMY_SPEED, state.world.player.position());
+            enemy.update(dt * ENEMY_SPEED + state.difficulty, state.world.player.position());
         }
     }
 }

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -7,6 +7,8 @@ use models::World;
 pub struct GameState {
     /// The world contains everything that needs to be drawn
     pub world: World,
+    /// The current difficulty - the enemies will speed up over time
+    pub difficulty: f64,
     /// The current score of the player
     pub score: u32
 }
@@ -17,6 +19,7 @@ impl GameState {
         let mut rng = rand::thread_rng();
         GameState {
             world: World::new(&mut rng, size),
+            difficulty: 0.0,
             score: 0
         }
     }
@@ -31,6 +34,9 @@ impl GameState {
 
         // Reset score
         self.score = 0;
+
+        // Reset difficulty
+        self.difficulty = 0.0;
 
         // Remove all enemies and bullets
         self.world.bullets.clear();


### PR DESCRIPTION
This makes it so that the enemies will slowly increase speed as time goes on, making it slightly harder to get higher scores (otherwise the game can get boring pretty fast). 
The enemy speed resets each time the player dies.

This could potentially close #68 as well.