### PR TITLE
Fix bug when events would carry over to next game

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -1,6 +1,5 @@
 use rand;
 
-use Resources;
 use geometry::{Position, Size};
 use models::World;
 
@@ -53,11 +52,12 @@ impl GameState {
     }
 
     /// Reset our game-state
-    pub fn reset(&mut self, resources: &Resources) {
+    pub fn reset(&mut self) {
         let mut rng = rand::thread_rng();
 
         // Reset player
         self.world.player.is_dead = false;
+        self.world.player.powerup = None;
         *self.world.player.x_mut() = self.world.size.random_x(&mut rng);
         *self.world.player.y_mut() = self.world.size.random_y(&mut rng);
 
@@ -67,12 +67,12 @@ impl GameState {
         // Reset difficulty
         self.difficulty = 0.0;
 
+        // Reset message
+        self.message = None;
+
         // Remove all enemies, bullets and powerups
         self.world.bullets.clear();
         self.world.enemies.clear();
         self.world.powerups.clear();
-
-        // Play game_start sound
-        let _ = resources.game_start_sound.play();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ pub struct ApplicationState {
 }
 
 impl ApplicationState {
+    /// Simply creates a new application state
     fn new(ctx: &mut Context, game_state: GameState) -> GameResult<ApplicationState> {
         let app_state = ApplicationState {
             has_focus: true,
@@ -60,6 +61,21 @@ impl ApplicationState {
             scheduled_events: PriorityQueue::new()
         };
         Ok(app_state)
+    }
+
+    /// This will be called when the game needs to be reset
+    fn reset(&mut self) {
+        // Empty scheduled events
+        while let Some(_) = self.scheduled_events.pop() {}
+
+        // Reset time controller
+        self.time_controller.reset();
+
+        // Reset game state
+        self.game_state.reset();
+
+        // Play game start sound
+        let _ = self.resources.game_start_sound.play();
     }
 }
 
@@ -94,9 +110,7 @@ impl event::EventHandler for ApplicationState {
     fn key_down_event(&mut self, _ctx: &mut Context, keycode: Keycode, keymod: Mod, _repeat: bool) {
         // If we're displaying a message (waiting for user input) then hide it and reset the game
         if let Some(_) = self.game_state.message {
-            self.game_state.message = None;
-            self.game_state.reset(&self.resources);
-            self.time_controller.reset();
+            self.reset();
         }
         self.input_controller.key_press(keycode, keymod);
     }


### PR DESCRIPTION
When the user had a powerup and then died, the powerup would carry over until the next game. So we should reset that as well. Also ensured that the `scheduled_events` heap was reset as well, and then abstracted the code into `main.rs` which seemed a little more logical to do.