### PR TITLE
Rust stable support.  Removed nightly NLL feature requirement.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,13 @@ environment:
 
   matrix:
       - TARGET: x86_64-pc-windows-gnu
-        CHANNEL: nightly
+        CHANNEL: stable
       - TARGET: i686-pc-windows-gnu
-        CHANNEL: nightly
+        CHANNEL: stable
+      - TARGET: x86_64-pc-windows-gnu
+        CHANNEL: beta
+      - TARGET: i686-pc-windows-gnu
+        CHANNEL: beta
 
 # Based on https://github.com/japaric/rust-everywhere/blob/master/appveyor.yml
 install:

--- a/src/controllers/time/mod.rs
+++ b/src/controllers/time/mod.rs
@@ -295,7 +295,8 @@ impl TimeController {
     fn update_stars(&mut self, dt: f32, state: &mut GameState, time_slow: bool) {
         for star in &mut state.world.stars {
             let base_speed = if time_slow { 20.0 } else { STAR_BASE_SPEED };
-            star.advance_wrapping(dt * base_speed * star.speed, state.world.size);
+            let speed = dt * base_speed * star.speed;
+            star.advance_wrapping(speed, state.world.size);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,6 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
-#![feature(nll)]
-
 extern crate ggez;
 extern crate itertools_num;
 extern crate rand;

--- a/src/models/enemy.rs
+++ b/src/models/enemy.rs
@@ -16,9 +16,10 @@ impl Enemy {
 
     /// Update the enemy
     pub fn update(&mut self, speed: f32, player_position: Point, size: Size) {
+        let vector_position = self.vector.position;
         // Point to the player
         self.point_to(nearest_virtual_position(
-            self.vector.position,
+            vector_position,
             player_position,
             size
         ));


### PR DESCRIPTION
Rust default is stable.  And NLL, although a great feature, isn't in stable yet.  So to get the game running like it says in the README running `cargo run --release` with a default stable install only a few quick variables needed to be created to show the compiler we aren't mutating the value of star.speed or vector.position.

I'm a Rust novice so sorry in advance if this isn't the right way to do it.